### PR TITLE
Add force move app storage option.

### DIFF
--- a/res/values/sshd_strings.xml
+++ b/res/values/sshd_strings.xml
@@ -546,4 +546,15 @@
 	<string name="qs_advanced_location_title">Advanced location settings</string>
     <string name="qs_advanced_location_summary">Enable advanced settings for location in quick settings</string>
 	<string name="quick_settings_reset_message">Reset quick settings tiles?</string>
+
+    <!-- Title of dialog to force change [CHAR LIMIT=25] -->
+    <string name="force_change">Force change</string>
+    <!-- Title of dialog to force change storage [CHAR LIMIT=25] -->
+    <string name="force_change_storage">Force change storage</string>
+    <string name="storage_wizard_move_confirm_force_info">\n\nWARNING: This app does not declare the ability for it to be moved to adopted storage.
+        You may forcibly move it regardless but app data may need to be cleared in order for it to function correctly.</string>
+    <string name="storage_wizard_move_confirm_body_cm">Moving <xliff:g id="app" example="Calculator">^1</xliff:g> and its data to <xliff:g id="name" example="SD card">^2</xliff:g> will take only a few moments. You won\u2019t be able to use the app until the move is complete.
+\n\nDon\u2019t remove the <xliff:g id="name" example="SD card">^2</xliff:g> during the move.<xliff:g id="forcetext">^3</xliff:g>
+ </string>
+
 </resources>

--- a/src/com/android/settings/applications/AppStorageSettings.java
+++ b/src/com/android/settings/applications/AppStorageSettings.java
@@ -345,8 +345,15 @@ public class AppStorageSettings extends AppInfoWithHeader
         final Context context = getActivity();
         final StorageManager storage = context.getSystemService(StorageManager.class);
 
-        final List<VolumeInfo> candidates = context.getPackageManager()
+        boolean requiresForce = false;
+        List<VolumeInfo> candidates = context.getPackageManager()
                 .getPackageCandidateVolumes(mAppEntry.info);
+        if (candidates.size() < 2) {
+            // try forceable volume list
+            candidates = context.getPackageManager()
+                .getPackageCandidateVolumesForceable(mAppEntry.info);
+            requiresForce = true;
+        }
         if (candidates.size() > 1) {
             Collections.sort(candidates, VolumeInfo.getDescriptionComparator());
 
@@ -359,9 +366,12 @@ public class AppStorageSettings extends AppInfoWithHeader
                 }
                 labels[i] = volDescrip;
             }
+            if (requiresForce) {
+                mChangeStorageButton.setText(R.string.force_change);
+            }
             mCandidates = candidates.toArray(new VolumeInfo[candidates.size()]);
             mDialogBuilder = new AlertDialog.Builder(getContext())
-                    .setTitle(R.string.change_storage)
+                    .setTitle(requiresForce ? R.string.force_change_storage : R.string.change_storage)
                     .setSingleChoiceItems(labels, current, this)
                     .setNegativeButton(R.string.cancel, null);
         } else {

--- a/src/com/android/settings/deviceinfo/StorageWizardMoveConfirm.java
+++ b/src/com/android/settings/deviceinfo/StorageWizardMoveConfirm.java
@@ -51,15 +51,22 @@ public class StorageWizardMoveConfirm extends StorageWizardBase {
         }
 
         // Sanity check that target volume is candidate
-        Preconditions.checkState(
-                getPackageManager().getPackageCandidateVolumes(mApp).contains(mVolume));
+        // and determine if the move was forced
+        boolean forcedMove = false;
+        if (!getPackageManager().getPackageCandidateVolumes(mApp).contains(mVolume)) {
+            Preconditions.checkState(
+                    getPackageManager().getPackageCandidateVolumesForceable(mApp).contains(mVolume));
+            forcedMove = true;
+        }
 
         final String appName = getPackageManager().getApplicationLabel(mApp).toString();
         final String volumeName = mStorage.getBestVolumeDescription(mVolume);
 
         setIllustrationInternal(true);
         setHeaderText(R.string.storage_wizard_move_confirm_title, appName);
-        setBodyText(R.string.storage_wizard_move_confirm_body, appName, volumeName);
+        final String forceText = forcedMove ?
+                getString(R.string.storage_wizard_move_confirm_force_info) : "";
+        setBodyText(R.string.storage_wizard_move_confirm_body_cm, appName, volumeName, forceText);
 
         getNextButton().setText(R.string.move_app);
     }


### PR DESCRIPTION
Allows apps that don't declare an install location
in their manifest to be moved.

Change-Id: I31bdee79afb1d7bb9319b92fda6a8ea331f0a662

Patchset: 1
http://review.cyanogenmod.org/#/c/126215/

Conflicts:
	res/values/cm_strings.xml